### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.rsc linguist-detectable=false


### PR DESCRIPTION
Add .gitattributes to to bypass the false detection of github as [Rascal](https://en.wikipedia.org/wiki/RascalMPL) programming language.

Before:
![before](https://user-images.githubusercontent.com/67213069/183778249-8a9fe21d-033e-4be9-99fa-9e7e7c70c12d.png)

After:
![after](https://user-images.githubusercontent.com/67213069/183778260-3d64d2e5-bd08-4256-955f-89f80fbc15d1.png)

